### PR TITLE
Add init.rb to autoload in Rails

### DIFF
--- a/html_truncator.gemspec
+++ b/html_truncator.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.description      = "Wants to truncate an HTML string properly? This gem is for you."
   s.summary          = "Wants to truncate an HTML string properly? This gem is for you."
   s.extra_rdoc_files = %w(README.md)
-  s.files            = Dir["MIT-LICENSE", "README.md", "Gemfile", "lib/**/*.rb"]
+  s.files            = Dir["MIT-LICENSE", "README.md", "Gemfile", "lib/**/*.rb", "init.rb"]
   s.require_paths    = ["lib"]
   s.rubygems_version = %q{1.3.7}
   s.add_dependency "nokogiri", "~>1.4"

--- a/init.rb
+++ b/init.rb
@@ -1,0 +1,2 @@
+# encoding: utf-8
+require "html_truncator"


### PR DESCRIPTION
This little patch makes `require "html_truncator"` unnecessary in a Rails environment. I'm not sure if it's useful outside of Rails, but I can't imagine it causing any harm.
