### PR TITLE
Don't truncate object tags

### DIFF
--- a/lib/html_truncator.rb
+++ b/lib/html_truncator.rb
@@ -31,6 +31,7 @@ end
 
 class Nokogiri::XML::Node
   def truncate(max, opts)
+    return [to_html(:indent => 0), 0, opts] if name == 'object'
     return ["", 1, opts] if max == 0 && !ellipsable?
     inner, remaining, opts = inner_truncate(max, opts)
     if inner.empty?

--- a/spec/html_truncator_spec.rb
+++ b/spec/html_truncator_spec.rb
@@ -140,4 +140,18 @@ EOS
 EOS
     HTML_Truncator.truncate(txt, 2).should =~ /<img src="\/foo.png"/
   end
+
+  it "should preserve <object> tags" do
+    txt = <<EOS
+<p>YouTube video embedded</p>
+<object width="420" height="315">
+  <param name="movie" value="//www.youtube.com/v/txqiwrbYGrs?version=3&amp;hl=en_US">
+  <param name="allowFullScreen" value="true">
+  <param name="allowscriptaccess" value="always">
+  <embed src="//www.youtube.com/v/txqiwrbYGrs?version=3&amp;hl=en_US" type="application/x-shockwave-flash" width="420" height="315" allowscriptaccess="always" allowfullscreen="true"></embed>
+</object>
+EOS
+    HTML_Truncator.truncate(txt, 10).should == txt
+    HTML_Truncator.truncate(txt, 2).should == '<p>YouTube video…</p>'
+  end
 end


### PR DESCRIPTION
`object` tags (with nested `param` and `embed` tags) should not be truncated, since the end result was an empty `object` tag.  For example, this YouTube embed tag...

```
<object width="420" height="315">
  <param name="movie" value="//www.youtube.com/v/txqiwrbYGrs?version=3&amp;hl=en_US">
  <param name="allowFullScreen" value="true">
  <param name="allowscriptaccess" value="always">
  <embed src="//www.youtube.com/v/txqiwrbYGrs?version=3&amp;hl=en_US" type="application/x-shockwave-flash" width="420" height="315" allowscriptaccess="always" allowfullscreen="true"></embed>
</object>
```

... was being returned in the truncated output as ...

```
<object width="420" height="315">   </object>
```

I've updated the parsing to pass through `object` tags intact without parsing the tag contents.

Feel free to suggest a more robust approach.
