### PR TITLE
Set uses #delete, not #remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ HTML_Truncator.truncate("<p>Lorem ipsum dolor sit amet.</p>", 3).html_truncated?
 You can ignore images in the text by overriding the `self_closing_tags` attribute:
 
 ```ruby
-HTML_Truncator.self_closing_tags.remove "img"
+HTML_Truncator.self_closing_tags.delete "img"
 HTML_Truncator.truncate("<p>Lorem ipsum <img src='...'>dolor sit amet.</p>", 3)
 # => "<p>Lorem ipsum dolor…</p>"
 ```


### PR DESCRIPTION
Following the example to remove images causes an exception (at least in Ruby 2.2) since Set does not implement a #remove method.