### PR TITLE
Add an explicit Rubygems source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,3 @@
+source 'https://rubygems.org'
+
 gemspec


### PR DESCRIPTION
This avoids a deprecation warning.