### PR TITLE
Support frozen string literals

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  RUBYOPT: "--enable-frozen-string-literal --debug-frozen-string-literal"
+
 jobs:
   test:
 

--- a/lib/html_truncator.rb
+++ b/lib/html_truncator.rb
@@ -33,10 +33,10 @@ end
 
 class Nokogiri::XML::Node
   def truncate(max, opts)
-    return ["", 1, opts] if max == 0 && !ellipsable?
+    return [+"", 1, opts] if max == 0 && !ellipsable?
     inner, remaining, opts = inner_truncate(max, opts)
     if inner.empty?
-      return [self_closing? ? to_html : "", max - remaining, opts]
+      return [self_closing? ? to_html : +"", max - remaining, opts]
     end
     children.remove
     add_child Nokogiri::HTML::DocumentFragment.parse(inner)
@@ -44,7 +44,7 @@ class Nokogiri::XML::Node
   end
 
   def inner_truncate(max, opts)
-    inner, remaining = "", max
+    inner, remaining = +"", max
     self.children.each do |node|
       txt, nb, opts = node.truncate(remaining, opts)
       remaining -= nb

--- a/spec/html_truncator_spec.rb
+++ b/spec/html_truncator_spec.rb
@@ -15,6 +15,10 @@ describe HTML_Truncator do
   let(:long_text)  { "<p>Foo " +  ("<b>Bar Baz</b> " * 100) + "Quux</p>" }
   let(:list_text)  { "<p>Foo:</p><ul>" +  ("<li>Bar Baz</li>\n" * 100) + "</ul>" }
 
+  it "should not modify empty text" do
+    HTML_Truncator.truncate("", 10).should == ""
+  end
+
   it "should not modify short text" do
     HTML_Truncator.truncate(short_text, 10).should == short_text
   end


### PR DESCRIPTION
This is to avoid deprecation warnings with the forthcoming change in Ruby 3.4 where modifying a string literal will cause a deprecation warning by default.
https://github.com/ruby/ruby/commit/12be40ae6be78ac41e8e3f3c313cc6f63e7fa6c4

Granted, it only impacts situations where empty strings are passed through, but I figure better to cover that off than expect consumers of this gem to have their own logic.

Also, doesn't hurt to always be testing against this to avoid any regressions.