### PR TITLE
CI: Add Ruby 3.4, 3.3 and drop 3.0 from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,12 +14,13 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - 3.4
+          - 3.3
           - 3.2
           - 3.1
-          - "3.0"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
This PR adds new versions of Ruby to the CI build matrix.

Also, keep actions/checkout up to date.