### PR TITLE
gemspec: Use https, and fix grammar

### DIFF
--- a/html_truncator.gemspec
+++ b/html_truncator.gemspec
@@ -4,11 +4,11 @@ Gem::Specification.new do |s|
   s.name             = "html_truncator"
   s.version          = HTML_Truncator::VERSION
   s.date             = Time.now.utc.strftime("%Y-%m-%d")
-  s.homepage         = "http://github.com/nono/HTML-Truncator"
+  s.homepage         = "https://github.com/nono/HTML-Truncator"
   s.authors          = "Bruno Michel"
   s.email            = "bmichel@menfin.info"
-  s.description      = "Wants to truncate an HTML string properly? This gem is for you."
-  s.summary          = "Wants to truncate an HTML string properly? This gem is for you."
+  s.description      = "Want to truncate an HTML string properly? This gem is for you."
+  s.summary          = "Want to truncate an HTML string properly? This gem is for you."
   s.extra_rdoc_files = %w(README.md)
   s.files            = Dir["MIT-LICENSE", "README.md", "Gemfile", "lib/**/*.rb", "init.rb"]
   s.require_paths    = ["lib"]


### PR DESCRIPTION
This trivial PR fixes grammar in description and uses https in the GitHub link.