### PR TITLE
CI: Drop EOL Ruby versions from build matrix, add 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,9 @@ jobs:
     strategy:
       matrix:
         ruby-version:
+          - '4.0'
           - 3.4
           - 3.3
-          - 3.2
-          - 3.1
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR cuts out the EOL'd versions. https://endoflife.date/ruby